### PR TITLE
Fix typo in options switch labels

### DIFF
--- a/extension/script/options.js
+++ b/extension/script/options.js
@@ -49,7 +49,7 @@ class Rule extends React.Component {
       }),
       button,
       React.createElement(antd.Switch, {
-        checkedChildren: "Backgrond",
+        checkedChildren: "Background",
         unCheckedChildren: "Default",
         defaultChecked: this.props.enabled,
         onChange: this.handleSwitch,
@@ -171,7 +171,7 @@ class RuleList extends React.Component {
             "Default behavior"
           ),
           React.createElement(antd.Switch, {
-            checkedChildren: "Backgrond",
+            checkedChildren: "Background",
             unCheckedChildren: "Default",
             checked: this.state.enabled,
             onChange: (checked, e) => this.handleSwitch(checked, e)


### PR DESCRIPTION
## Summary
- fix Background label spelling in options page switches

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689d97e1a31883249407fd2e3b1df8b7